### PR TITLE
Fix formatting

### DIFF
--- a/liquidrazor/dto-api-bundle/0.1/config/packages/liquidrazor_dto_api.yaml
+++ b/liquidrazor/dto-api-bundle/0.1/config/packages/liquidrazor_dto_api.yaml
@@ -1,13 +1,13 @@
 # Default, safe config
 liquidrazor_dto_api:
-  normalizer_priority: 10
-  strict_types: true
-  # Use '3.0.3' if you need max Redoc OSS compatibility
-  openapi_version: '3.1.0'
-  default_responses:
-    422:
-      class: LiquidRazor\DtoApiBundle\Response\ValidationErrorResponse
-      description: 'Validation error'
-    500:
-      class: LiquidRazor\DtoApiBundle\Response\ErrorResponse
-      description: 'Server error'
+    normalizer_priority: 10
+    strict_types: true
+    # Use '3.0.3' if you need max Redoc OSS compatibility
+    openapi_version: '3.1.0'
+    default_responses:
+        422:
+            class: LiquidRazor\DtoApiBundle\Response\ValidationErrorResponse
+            description: 'Validation error'
+        500:
+            class: LiquidRazor\DtoApiBundle\Response\ErrorResponse
+            description: 'Server error'

--- a/liquidrazor/dto-api-bundle/0.1/config/routes/liquidrazor_dto_api.yaml
+++ b/liquidrazor/dto-api-bundle/0.1/config/routes/liquidrazor_dto_api.yaml
@@ -1,4 +1,4 @@
 # Wire the auto-docs + schema + listener routes from the bundle
 liquidrazor_dto_api:
-  resource: '@LiquidRazorDtoApiBundle/Resources/config/routes.php'
-  prefix: /
+    resource: '@LiquidRazorDtoApiBundle/Resources/config/routes.php'
+    prefix: /

--- a/liquidrazor/dto-api-bundle/0.1/manifest.json
+++ b/liquidrazor/dto-api-bundle/0.1/manifest.json
@@ -1,8 +1,14 @@
 {
     "bundles": {
-        "LiquidRazor\\DtoApiBundle\\LiquidRazorDtoApiBundle": ["all"]
+        "LiquidRazor\\DtoApiBundle\\LiquidRazorDtoApiBundle": [
+            "all"
+        ]
     },
-    "aliases": ["dto-api", "dtoapi", "liquidrazor-dto"],
+    "aliases": [
+        "dto-api",
+        "dtoapi",
+        "liquidrazor-dto"
+    ],
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
     },


### PR DESCRIPTION
Fix formatting in liquidrazor/dto-api-bundle recipe (config, routes, manifest) (4 spaces as per call-qa / Run checks)